### PR TITLE
Fix README repo clone and cd instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ A Python framework to emulate **Grok heavy** functionality using a powerful mult
 
 1. **Clone and setup environment:**
 ```bash
-git clone <https://github.com/Doriandarko/make-it-heavy.git>
-cd "make it heavy"
+git clone https://github.com/Doriandarko/make-it-heavy.git
+cd "make-it-heavy"
 
 # Create virtual environment with uv
 uv venv


### PR DESCRIPTION
Line 27 and 28 were edited to prevent the following terminal errors: 
zsh: parse error near `\n'
cd: no such file or directory: make it heavy